### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "es6-promise": "3.0.2",
     "es6-shim": "0.33.3",
     "express": "4.13.3",
-    "gulp-concat": "2.6.0",
     "reflect-metadata": "0.1.2",
     "rxjs": "5.0.0-beta.0",
     "systemjs": "0.19.16",


### PR DESCRIPTION
FIX for:
npm WARN package.json Dependency 'gulp-concat' exists in both dependencies and devDependencies, using 'gulp-concat@2.6.0' from dependencies
